### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/homeconnect/__init__.py
+++ b/custom_components/homeconnect/__init__.py
@@ -40,6 +40,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required('client_id'): cv.string,
         vol.Required('client_secret'): cv.string,
         vol.Optional('simulate', default=False): cv.boolean,
+        vol.Optional('callback_url', default='none'): cv.string,
     })
 }, extra=vol.ALLOW_EXTRA)
 
@@ -47,7 +48,11 @@ CONFIG_SCHEMA = vol.Schema({
 def setup(hass, config, add_entities=None):
     """Set up Home Connect component."""
     from homeconnect import HomeConnect
-    redirect_uri = '{}{}'.format(hass.config.api.base_url, AUTH_CALLBACK_PATH)
+    if config.get(DOMAIN, {}).get('callback_url', 'none') == 'none':
+     conf_callback = hass.config.api.base_url
+    else:
+     conf_callback = config.get(DOMAIN, {}).get('callback_url', 'none')
+    redirect_uri = '{}{}'.format(conf_callback, AUTH_CALLBACK_PATH)
 
     token_cache = hass.config.path(CACHE_PATH)
     hc = HomeConnect(client_id=config.get(DOMAIN, {}).get('client_id', ''),
@@ -340,6 +345,7 @@ class Washer(DeviceWithDoor, DeviceWithPrograms, HomeConnectDevice):
 
     _programs = [
         {'name': 'LaundryCare.Washer.Program.Cotton',},
+        {'name': 'LaundryCare.Washer.Program.Cotton.CottonEco',},
         {'name': 'LaundryCare.Washer.Program.EasyCare',},
         {'name': 'LaundryCare.Washer.Program.Mix',},
         {'name': 'LaundryCare.Washer.Program.DelicatesSilk',},


### PR DESCRIPTION
Update of CONFIG_SCHEMA to support static callback_url. (When running the custom component in a Docker container, "hass.config.api.base_url" is trying to expose the internal container IP as callback). If config parameter "callback_url" is not given, variable "hass.config.api.base_url" is still used as fallback.
Also, added yet another Washer program on row 348

If this change is merged, please also update the README with the new config parameter