### PR TITLE
fixed version of HA dependency

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Home Connect",
     "domains": ["sensor", "binary_sensor", "switch"],
-    "homeassistant": "0.102.0",
+    "homeassistant": "0.102",
     "render_readme": true
 }


### PR DESCRIPTION
Fixed HA verision, no trailing zeros in version 0.102. 
Tested with new docker version of HA (0.102.0)