### PR TITLE
Switch on/off

### DIFF
--- a/custom_components/homeconnect/switch.py
+++ b/custom_components/homeconnect/switch.py
@@ -26,9 +26,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
         data = hass.data[DOMAIN]
         for device_dict in data.get(DEVICES, []):
-            entities += [HomeConnectPowerSwitch(device_dict["device"])]
             entity_dicts = device_dict.get("entities", {}).get("switch", [])
-            entity_list = [HomeConnectProgramSwitch(**d) for d in entity_dicts]
+            entity_list = [HomeConnectProgramSwitch(**d) for d in entity_dicts] + [HomeConnectPowerSwitch(device_dict["device"])]
             device = device_dict["device"]
             device.entities += entity_list
             entities += entity_list


### PR DESCRIPTION
Change fixed the problem that appliance was starting, but switch was switching back to "off" immediately as well as not updating automatically ("listening" to API) if something changed directly on the device. I've tried (&error) some things and changed the switch.py as following - both working now with my appliances (coffee machine, oven, dishwasher) w/o any issues.

Unfortunately, had some instability of the homeconnect services when testing over the last week. If there is no action for a longer time the service is not automatically "listening" any more to the API (this is true for all types, switches, sensors and binary_sensors) --> no debug entries when opening / closing a door or changing any state directly at the device, error message when using the switch (home appliance can't be reached).