### PR TITLE
load available programs from api and add service calls for appliance programs 

### DIFF
--- a/custom_components/homeconnect/api.py
+++ b/custom_components/homeconnect/api.py
@@ -153,11 +153,11 @@ class HomeConnectEntity(Entity):
 class DeviceWithPrograms(HomeConnectDevice):
     """Device with programs."""
 
-    _programs = []
-
     def get_programs_available(self):
         """Get the available programs."""
-        return self._programs
+        programs = self.appliance.get_programs_available()
+        _LOGGER.debug("available programs: {}".format(programs))
+        return [{"name": p} for p in programs]
 
     def get_program_switches(self):
         """Get a dictionary with info about program switches.
@@ -205,25 +205,6 @@ class DeviceWithDoor(HomeConnectDevice):
 class Dryer(DeviceWithDoor, DeviceWithPrograms):
     """Dryer class."""
 
-    _programs = [
-        {"name": "LaundryCare.Dryer.Program.Cotton"},
-        {"name": "LaundryCare.Dryer.Program.Synthetic"},
-        {"name": "LaundryCare.Dryer.Program.Mix"},
-        {"name": "LaundryCare.Dryer.Program.Blankets"},
-        {"name": "LaundryCare.Dryer.Program.BusinessShirts"},
-        {"name": "LaundryCare.Dryer.Program.DownFeathers"},
-        {"name": "LaundryCare.Dryer.Program.Hygiene"},
-        {"name": "LaundryCare.Dryer.Program.Jeans"},
-        {"name": "LaundryCare.Dryer.Program.Outdoor"},
-        {"name": "LaundryCare.Dryer.Program.SyntheticRefresh"},
-        {"name": "LaundryCare.Dryer.Program.Towels"},
-        {"name": "LaundryCare.Dryer.Program.Delicates"},
-        {"name": "LaundryCare.Dryer.Program.Super40"},
-        {"name": "LaundryCare.Dryer.Program.Shirts15"},
-        {"name": "LaundryCare.Dryer.Program.Pillow"},
-        {"name": "LaundryCare.Dryer.Program.AntiShrink"},
-    ]
-
     def get_entities(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
@@ -239,31 +220,6 @@ class Dryer(DeviceWithDoor, DeviceWithPrograms):
 class Dishwasher(DeviceWithDoor, DeviceWithPrograms):
     """Dishwasher class."""
 
-    _programs = [
-        {"name": "Dishcare.Dishwasher.Program.Auto1"},
-        {"name": "Dishcare.Dishwasher.Program.Auto2"},
-        {"name": "Dishcare.Dishwasher.Program.Auto3"},
-        {"name": "Dishcare.Dishwasher.Program.Eco50"},
-        {"name": "Dishcare.Dishwasher.Program.Quick45"},
-        {"name": "Dishcare.Dishwasher.Program.Intensiv70"},
-        {"name": "Dishcare.Dishwasher.Program.Normal65"},
-        {"name": "Dishcare.Dishwasher.Program.Glas40"},
-        {"name": "Dishcare.Dishwasher.Program.GlassCare"},
-        {"name": "Dishcare.Dishwasher.Program.NightWash"},
-        {"name": "Dishcare.Dishwasher.Program.Quick65"},
-        {"name": "Dishcare.Dishwasher.Program.Normal45"},
-        {"name": "Dishcare.Dishwasher.Program.Intensiv45"},
-        {"name": "Dishcare.Dishwasher.Program.AutoHalfLoad"},
-        {"name": "Dishcare.Dishwasher.Program.IntensivPower"},
-        {"name": "Dishcare.Dishwasher.Program.MagicDaily"},
-        {"name": "Dishcare.Dishwasher.Program.Super60"},
-        {"name": "Dishcare.Dishwasher.Program.Kurz60"},
-        {"name": "Dishcare.Dishwasher.Program.ExpressSparkle65"},
-        {"name": "Dishcare.Dishwasher.Program.MachineCare"},
-        {"name": "Dishcare.Dishwasher.Program.SteamFresh"},
-        {"name": "Dishcare.Dishwasher.Program.MaximumCleaning"},
-    ]
-
     def get_entities(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
@@ -278,14 +234,6 @@ class Dishwasher(DeviceWithDoor, DeviceWithPrograms):
 
 class Oven(DeviceWithDoor, DeviceWithPrograms):
     """Oven class."""
-
-    _programs = [
-        {"name": "Cooking.Oven.Program.HeatingMode.PreHeating"},
-        {"name": "Cooking.Oven.Program.HeatingMode.HotAir"},
-        {"name": "Cooking.Oven.Program.HeatingMode.TopBottomHeating"},
-        {"name": "Cooking.Oven.Program.HeatingMode.PizzaSetting"},
-        {"name": "Cooking.Oven.Program.Microwave.600Watt"},
-    ]
 
     power_off_state = "BSH.Common.EnumType.PowerState.Standby"
 
@@ -304,30 +252,6 @@ class Oven(DeviceWithDoor, DeviceWithPrograms):
 class Washer(DeviceWithDoor, DeviceWithPrograms):
     """Washer class."""
 
-    _programs = [
-        {"name": "LaundryCare.Washer.Program.Cotton"},
-        {"name": "LaundryCare.Washer.Program.Cotton.CottonEco"},
-        {"name": "LaundryCare.Washer.Program.EasyCare"},
-        {"name": "LaundryCare.Washer.Program.Mix"},
-        {"name": "LaundryCare.Washer.Program.DelicatesSilk"},
-        {"name": "LaundryCare.Washer.Program.Wool"},
-        {"name": "LaundryCare.Washer.Program.Sensitive"},
-        {"name": "LaundryCare.Washer.Program.Auto30"},
-        {"name": "LaundryCare.Washer.Program.Auto40"},
-        {"name": "LaundryCare.Washer.Program.Auto60"},
-        {"name": "LaundryCare.Washer.Program.Chiffon"},
-        {"name": "LaundryCare.Washer.Program.Curtains"},
-        {"name": "LaundryCare.Washer.Program.DarkWash"},
-        {"name": "LaundryCare.Washer.Program.Dessous"},
-        {"name": "LaundryCare.Washer.Program.Monsoon"},
-        {"name": "LaundryCare.Washer.Program.Outdoor"},
-        {"name": "LaundryCare.Washer.Program.PlushToy"},
-        {"name": "LaundryCare.Washer.Program.ShirtsBlouses"},
-        {"name": "LaundryCare.Washer.Program.SportFitness"},
-        {"name": "LaundryCare.Washer.Program.Towels"},
-        {"name": "LaundryCare.Washer.Program.WaterProof"},
-    ]
-
     def get_entities(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
@@ -343,15 +267,6 @@ class Washer(DeviceWithDoor, DeviceWithPrograms):
 class CoffeeMaker(DeviceWithPrograms):
     """Coffee maker class."""
 
-    _programs = [
-        {"name": "ConsumerProducts.CoffeeMaker.Program.Beverage.Espresso"},
-        {"name": "ConsumerProducts.CoffeeMaker.Program.Beverage.EspressoMacchiato"},
-        {"name": "ConsumerProducts.CoffeeMaker.Program.Beverage.Coffee"},
-        {"name": "ConsumerProducts.CoffeeMaker.Program.Beverage.Cappuccino"},
-        {"name": "ConsumerProducts.CoffeeMaker.Program.Beverage.LatteMacchiato"},
-        {"name": "ConsumerProducts.CoffeeMaker.Program.Beverage.CaffeLatte"},
-    ]
-
     power_off_state = "BSH.Common.EnumType.PowerState.Standby"
 
     def get_entities(self):
@@ -363,12 +278,6 @@ class CoffeeMaker(DeviceWithPrograms):
 
 class Hood(DeviceWithPrograms):
     """Hood class."""
-
-    _programs = [
-        {"name": "Cooking.Common.Program.Hood.Automatic"},
-        {"name": "Cooking.Common.Program.Hood.Venting"},
-        {"name": "Cooking.Common.Program.Hood.DelayedShutOff"},
-    ]
 
     def get_entities(self):
         """Get a dictionary with infos about the associated entities."""
@@ -388,8 +297,6 @@ class FridgeFreezer(DeviceWithDoor):
 
 class Hob(DeviceWithPrograms):
     """Hob class."""
-
-    _programs = [{"name": "Cooking.Hob.Program.PowerLevelMode"}]
 
     def get_entities(self):
         """Get a dictionary with infos about the associated entities."""

--- a/custom_components/homeconnect/binary_sensor.py
+++ b/custom_components/homeconnect/binary_sensor.py
@@ -8,10 +8,13 @@ import logging
 from homeassistant.components.binary_sensor import BinarySensorDevice, DEVICE_CLASS_DOOR
 
 from .api import HomeConnectEntity
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    BINARY_SENSORS_ON_STATES,
+    BINARY_SENSORS_OFF_STATES,
+)
 
 _LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Home Connect binary sensor."""
@@ -32,16 +35,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorDevice):
     """Binary sensor for Home Connect."""
-
-    _OFF_STATES = [
-                "BSH.Common.EnumType.DoorState.Closed",
-                "BSH.Common.EnumType.DoorState.Locked",
-            ]
-    
-    _ON_STATES = [
-                "BSH.Common.EnumType.DoorState.Open",
-            ]
-
 
     def __init__(self, device, name, key, device_class = None):
         """Initialize the entitiy."""
@@ -67,9 +60,9 @@ class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorDevice):
             self._state = None
         elif isinstance(state.get("value", None), bool):
             self._state = state.get("value", None)
-        elif state.get("value", None) in self._OFF_STATES:
+        elif state.get("value", None) in BINARY_SENSORS_OFF_STATES:
             self._state = False
-        elif state.get("value", None) in self._ON_STATES:
+        elif state.get("value", None) in BINARY_SENSORS_ON_STATES:
             self._state = True
         else:
             _LOGGER.warning("Unexpected value for HomeConnect door state: %s", state)

--- a/custom_components/homeconnect/const.py
+++ b/custom_components/homeconnect/const.py
@@ -2,5 +2,39 @@
 
 DOMAIN = "homeconnect"
 
+DEVICES = "DEVICES"
+
 OAUTH2_AUTHORIZE = "https://api.home-connect.com/security/oauth/authorize"
 OAUTH2_TOKEN = "https://api.home-connect.com/security/oauth/token"
+
+BINARY_SENSORS_OFF_STATES = [
+        "BSH.Common.EnumType.DoorState.Closed",
+        "BSH.Common.EnumType.DoorState.Locked",
+    ]
+    
+BINARY_SENSORS_ON_STATES = [
+        "BSH.Common.EnumType.DoorState.Open",
+    ]
+
+
+SERVICE_STARTPROGRAM = "start_program"
+SERVICE_STOPPROGRAM = "stop_program"
+PROGRAM_NAMES = {
+        "Cooking.Oven.Program.HeatingMode.HotAir": "hot_air",
+        "Cooking.Oven.Program.HeatingMode.TopBottomHeating": "top_bottom_heating",
+        "Cooking.Oven.Program.HeatingMode.HotAirEco": "hot_air_eco",
+        "Cooking.Oven.Program.HeatingMode.TopBottomHeatingEco": "top_bottom_heating_eco",
+        "Cooking.Oven.Program.HeatingMode.HotAirGrilling": "hot_air_grilling",
+        "Cooking.Oven.Program.HeatingMode.PizzaSetting": "pizza_setting",
+        "Cooking.Oven.Program.HeatingMode.SlowCook": "slow_cook",
+        "Cooking.Oven.Program.HeatingMode.BottomHeating": "bottom_heating",
+        "Cooking.Oven.Program.HeatingMode.Defrost": "defrost",
+        "Cooking.Oven.Program.HeatingMode.KeepWarm": "keep_warm",
+        "Cooking.Oven.Program.HeatingMode.PreheatOvenware": "preheat_ovenware",
+    }
+PROGRAM_OPTIONS = {
+        "Cooking.Oven.Option.SetpointTemperature": "setpoint_temperature",
+        "BSH.Common.Option.Duration": "duration",
+        "BSH.Common.Option.StartInRelative": "start_in_relative",
+        "Cooking.Oven.Option.FastPreHeat": "fast_pre_heat",
+    }

--- a/custom_components/homeconnect/sensor.py
+++ b/custom_components/homeconnect/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
 
 _LOGGER = logging.getLogger(__name__)
 
-
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Home Connect sensor."""
 
@@ -26,6 +25,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             device = device_dict["device"]
             device.entities += entity_list
             entities += entity_list
+            if device.has_programs:
+                services = device.get_programs_services()
+                _LOGGER.debug(f"services to register: {services}")
+                for s in services:
+                    _LOGGER.debug(f"registering service {s['service_name']}")
+                    hass.services.async_register(
+                        s['service_domain'],
+                        s['service_name'],
+                        s['service_callback'],
+                        schema=s['service_schema'],
+                    )
         return entities
 
     async_add_entities(await hass.async_add_executor_job(get_entities), True)

--- a/custom_components/homeconnect/services.yaml
+++ b/custom_components/homeconnect/services.yaml
@@ -1,0 +1,149 @@
+oven_stop_program:
+  description: Stop the oven active program.
+
+oven_start_program_hot_air:
+  description: Start oven Hot Air program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    fast_pre_heat:
+      description: The cooking compartment is heated up quickly if true
+      example: True
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_hot_air_eco:
+  description: Start oven Hot Air Eco program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_top_bottom_heating_eco:
+  description: Start oven Top Bottom Heating Eco program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_top_bottom_heating:
+  description: Start oven Top Bottom Heating program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    fast_pre_heat:
+      description: The cooking compartment is heated up quickly if true
+      example: True
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_hot_air_grilling:
+  description: Start oven Hot Air Grilling program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_pizza_setting:
+  description: Start oven Pizza Setting program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_slow_cook:
+  description: Start oven Slow Cook program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_bottom_heating:
+  description: Start oven Bottom Heating program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_defrost:
+  description: Start oven Defrost program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+
+oven_start_program_keep_warm:
+  description: Start oven Keep Warm program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+
+oven_start_program_preheat_ovenware:
+  description: Start oven Preheat Ovenware program.
+  fields:
+    setpoint_temperature:
+      description: Target cavity temperature in C.
+      example: 180
+    duration:
+      description: Run time of the program in seconds.
+      example: 600
+    start_in_relative:
+      description: The program will be activated but not started until the defined time span in seconds elapses.
+      example: 180
+

--- a/custom_components/homeconnect/switch.py
+++ b/custom_components/homeconnect/switch.py
@@ -82,7 +82,7 @@ class HomeConnectProgramSwitch(HomeConnectEntity, SwitchDevice):
             self._state = True
         else:
             self._state = False
-        _LOGGER.debug("Updated, new state: %s", self._state)
+        _LOGGER.debug("Switch {} updated, new state: {}".format(self._name, self._state))
 
 
 def convert_to_snake(camel):
@@ -175,7 +175,7 @@ class HomeConnectPowerSwitch(HomeConnectEntity, SwitchDevice):
             self._state = False
         else:
             self._state = None
-        _LOGGER.debug("Updated, new state: %s", self._state)
+        _LOGGER.debug("Switch {} updated, new state: {}".format(self._name, self._state))
 
     @property
     def device_state_attributes(self):


### PR DESCRIPTION
- load available programs from api for each appliance instead of having them written in the code

Added handling of appliance specific sensors:
- add appliance specific sensors and binary_sensors
- include sensors and binary_sensors device_class and unit implementation
- usage of homeassistant constants for device classes and sensor units