### PR TITLE
port remote sensors from core to beta

### DIFF
--- a/custom_components/home_connect_beta/api.py
+++ b/custom_components/home_connect_beta/api.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.dispatcher import dispatcher_send
 from .const import (
     BSH_ACTIVE_PROGRAM,
     BSH_AMBIENTLIGHTENABLED,
+    BSH_OPERATION_STATE,
     BSH_POWER_OFF,
     BSH_POWER_STANDBY,
     COOKING_LIGHTING,
@@ -161,6 +162,25 @@ class DeviceWithPrograms(HomeConnectDevice):
         ]
 
 
+class DeviceWithOpState(HomeConnectDevice):
+    """Device that has an operation state sensor."""
+
+    def get_opstate_sensor(self):
+        """Get a list with info about operation state sensors."""
+
+        return [
+            {
+                "device": self,
+                "desc": "Operation State",
+                "unit": None,
+                "key": BSH_OPERATION_STATE,
+                "icon": "mdi:state-machine",
+                "device_class": None,
+                "sign": 1,
+            }
+        ]
+
+
 class DeviceWithDoor(HomeConnectDevice):
     """Device that has a door sensor."""
 
@@ -169,6 +189,7 @@ class DeviceWithDoor(HomeConnectDevice):
         return {
             "device": self,
             "desc": "Door",
+            "sensor_type": "door",
             "device_class": "door",
         }
 
@@ -197,7 +218,37 @@ class DeviceWithAmbientLight(HomeConnectDevice):
         }
 
 
-class Dryer(DeviceWithDoor, DeviceWithPrograms):
+class DeviceWithRemoteControl(HomeConnectDevice):
+    """Device that has Remote Control binary sensor."""
+
+    def get_remote_control(self):
+        """Get a dictionary with info about the remote control sensor."""
+        return {
+            "device": self,
+            "desc": "Remote Control",
+            "sensor_type": "remote_control",
+        }
+
+
+class DeviceWithRemoteStart(HomeConnectDevice):
+    """Device that has a Remote Start binary sensor."""
+
+    def get_remote_start(self):
+        """Get a dictionary with info about the remote start sensor."""
+        return {
+            "device": self,
+            "desc": "Remote Start",
+            "sensor_type": "remote_start",
+        }
+
+
+class Dryer(
+    DeviceWithDoor,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
     """Dryer class."""
 
     PROGRAMS = [
@@ -222,17 +273,26 @@ class Dryer(DeviceWithDoor, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
-class WasherDryer(DeviceWithDoor, DeviceWithPrograms):
-    """Washer class."""
+class WasherDryer(
+    DeviceWithDoor,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
+    """WasherDryer class."""
 
     PROGRAMS = [
         {"name": "LaundryCare.Washer.Program.Cotton"},
@@ -277,16 +337,26 @@ class WasherDryer(DeviceWithDoor, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
-class Dishwasher(DeviceWithDoor, DeviceWithAmbientLight, DeviceWithPrograms):
+class Dishwasher(
+    DeviceWithDoor,
+    DeviceWithAmbientLight,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
     """Dishwasher class."""
 
     PROGRAMS = [
@@ -318,17 +388,26 @@ class Dishwasher(DeviceWithDoor, DeviceWithAmbientLight, DeviceWithPrograms):
         """Get a dictionary with infos about the associated entities."""
         ambientlight_entity = self.get_ambientlight_entity()
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
             "light": [ambientlight_entity]
         }
 
 
-class Oven(DeviceWithDoor, DeviceWithPrograms):
+class Oven(
+    DeviceWithDoor,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
     """Oven class."""
 
     PROGRAMS = [
@@ -353,16 +432,25 @@ class Oven(DeviceWithDoor, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
-class Washer(DeviceWithDoor, DeviceWithPrograms):
+class Washer(
+    DeviceWithDoor,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
     """Washer class."""
 
     PROGRAMS = [
@@ -392,16 +480,19 @@ class Washer(DeviceWithDoor, DeviceWithPrograms):
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
-            "binary_sensor": [door_entity],
+            "binary_sensor": [door_entity, remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
         }
 
 
-class CoffeeMaker(DeviceWithPrograms):
+class CoffeeMaker(DeviceWithOpState, DeviceWithPrograms, DeviceWithRemoteStart):
     """Coffee maker class."""
 
     PROGRAMS = [
@@ -440,12 +531,25 @@ class CoffeeMaker(DeviceWithPrograms):
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
+        remote_start = self.get_remote_start()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
-        return {"switch": program_switches, "sensor": program_sensors}
+        return {
+            "binary_sensor": [remote_start],
+            "switch": program_switches,
+            "sensor": program_sensors + op_state_sensor,
+        }
 
 
-class Hood(DeviceWithLight, DeviceWithAmbientLight, DeviceWithPrograms):
+class Hood(
+    DeviceWithLight,
+    DeviceWithAmbientLight,
+    DeviceWithOpState,
+    DeviceWithPrograms,
+    DeviceWithRemoteControl,
+    DeviceWithRemoteStart,
+):
     """Hood class."""
 
     PROGRAMS = [
@@ -456,13 +560,17 @@ class Hood(DeviceWithLight, DeviceWithAmbientLight, DeviceWithPrograms):
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
+        remote_control = self.get_remote_control()
+        remote_start = self.get_remote_start()
         light_entity = self.get_light_entity()
         ambientlight_entity = self.get_ambientlight_entity()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
         return {
+            "binary_sensor": [remote_control, remote_start],
             "switch": program_switches,
-            "sensor": program_sensors,
+            "sensor": program_sensors + op_state_sensor,
             "light" : [light_entity, ambientlight_entity]
         }
 
@@ -476,13 +584,20 @@ class FridgeFreezer(DeviceWithDoor):
         return {"binary_sensor": [door_entity]}
 
 
-class Hob(DeviceWithPrograms):
+class Hob(DeviceWithOpState, DeviceWithPrograms, DeviceWithRemoteControl):
     """Hob class."""
 
     PROGRAMS = [{"name": "Cooking.Hob.Program.PowerLevelMode"}]
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
+        remote_control = self.get_remote_control()
+        op_state_sensor = self.get_opstate_sensor()
         program_sensors = self.get_program_sensors()
         program_switches = self.get_program_switches()
-        return {"switch": program_switches, "sensor": program_sensors}
+        return {
+            "binary_sensor": [remote_control],
+            "switch": program_switches,
+            "sensor": program_sensors + op_state_sensor,
+        }
+

--- a/custom_components/home_connect_beta/binary_sensor.py
+++ b/custom_components/home_connect_beta/binary_sensor.py
@@ -3,7 +3,12 @@ import logging
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
-from .const import BSH_DOOR_STATE, DOMAIN
+from .const import (
+    BSH_DOOR_STATE,
+    BSH_REMOTE_CONTROL_ACTIVATION_STATE,
+    BSH_REMOTE_START_ALLOWANCE_STATE,
+    DOMAIN,
+)
 from .entity import HomeConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,11 +31,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
     """Binary sensor for Home Connect."""
 
-    def __init__(self, device, desc, device_class):
+    def __init__(self, device, desc, sensor_type, device_class=None):
         """Initialize the entity."""
         super().__init__(device, desc)
-        self._device_class = device_class
         self._state = None
+        self._device_class = device_class
+        self._type = sensor_type
+        if self._type == "door":
+            self._update_key = BSH_DOOR_STATE
+            self._false_value_list = (
+                "BSH.Common.EnumType.DoorState.Closed",
+                "BSH.Common.EnumType.DoorState.Locked",
+            )
+            self._true_value_list = ["BSH.Common.EnumType.DoorState.Open"]
+        elif self._type == "remote_control":
+            self._update_key = BSH_REMOTE_CONTROL_ACTIVATION_STATE
+            self._false_value_list = [False]
+            self._true_value_list = [True]
+        elif self._type == "remote_start":
+            self._update_key = BSH_REMOTE_START_ALLOWANCE_STATE
+            self._false_value_list = [False]
+            self._true_value_list = [True]
 
     @property
     def is_on(self):
@@ -44,18 +65,17 @@ class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
 
     async def async_update(self):
         """Update the binary sensor's status."""
-        state = self.device.appliance.status.get(BSH_DOOR_STATE, {})
+        state = self.device.appliance.status.get(self._update_key, {})
         if not state:
             self._state = None
-        elif state.get("value") in [
-            "BSH.Common.EnumType.DoorState.Closed",
-            "BSH.Common.EnumType.DoorState.Locked",
-        ]:
+        elif state.get("value") in self._false_value_list:
             self._state = False
-        elif state.get("value") == "BSH.Common.EnumType.DoorState.Open":
+        elif state.get("value") in self._true_value_list:
             self._state = True
         else:
-            _LOGGER.warning("Unexpected value for HomeConnect door state: %s", state)
+            _LOGGER.warning(
+                "Unexpected value for HomeConnect %s state: %s", self._type, state
+            )
             self._state = None
         _LOGGER.debug("Updated, new state: %s", self._state)
 

--- a/custom_components/home_connect_beta/const.py
+++ b/custom_components/home_connect_beta/const.py
@@ -11,6 +11,8 @@ BSH_POWER_OFF = "BSH.Common.EnumType.PowerState.Off"
 BSH_POWER_STANDBY = "BSH.Common.EnumType.PowerState.Standby"
 BSH_ACTIVE_PROGRAM = "BSH.Common.Root.ActiveProgram"
 BSH_OPERATION_STATE = "BSH.Common.Status.OperationState"
+BSH_REMOTE_CONTROL_ACTIVATION_STATE = "BSH.Common.Status.RemoteControlActive"
+BSH_REMOTE_START_ALLOWANCE_STATE = "BSH.Common.Status.RemoteControlStartAllowed"
 
 COOKING_LIGHTING = "Cooking.Common.Setting.Lighting"
 COOKING_LIGHTINGBRIGHTNESS = "Cooking.Common.Setting.LightingBrightness"

--- a/custom_components/home_connect_beta/sensor.py
+++ b/custom_components/home_connect_beta/sensor.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.const import DEVICE_CLASS_TIMESTAMP
 import homeassistant.util.dt as dt_util
 
-from .const import DOMAIN
+from .const import BSH_OPERATION_STATE, DOMAIN
 from .entity import HomeConnectEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class HomeConnectSensor(HomeConnectEntity):
         return self._state is not None
 
     async def async_update(self):
-        """Update the sensos status."""
+        """Update the sensor's status."""
         status = self.device.appliance.status
         if self._key not in status:
             self._state = None
@@ -74,6 +74,11 @@ class HomeConnectSensor(HomeConnectEntity):
                     ).isoformat()
             else:
                 self._state = status[self._key].get("value")
+                if self._key == BSH_OPERATION_STATE:
+                    # Value comes back as an enum, we only really care about the
+                    # last part, so split it off
+                    # https://developer.home-connect.com/docs/status/operation_state
+                    self._state = self._state.split(".")[-1]
         _LOGGER.debug("Updated, new state: %s", self._state)
 
     @property


### PR DESCRIPTION
This is a copy of https://github.com/home-assistant/core/pull/45610/ that is already merged in the home_connect integration in Home Assistant core. It adds binary sensors for Remote Control Activation State and Remote Start Allowance State, which are either on or off.
It also adds a sensor for Operation State which has a number of different state values depending on what type of machine we are dealing with and what the machine is doing

It is basically a straight copy, though also adds the right bits to the WasherDryer class which doesn't exist in core.

closes: #99 